### PR TITLE
Fix IllegalStateException: activity already destroyed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 
 android {
 
-    compileSdkVersion 24
-    buildToolsVersion "24.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         applicationId "com.example.replacefragments"
         minSdkVersion 19
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
 
@@ -18,14 +18,9 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:24.2.0'
-    compile 'com.android.support:design:24.2.0'
+    compile 'com.android.support:appcompat-v7:25.0.1'
+    compile 'com.android.support:design:25.0.1'
     compile 'com.google.code.gson:gson:2.7'
     compile 'io.reactivex:rxjava:1.1.10'
     compile 'io.reactivex:rxandroid:1.2.1'
-//    compile 'com.squareup.okhttp3:okhttp:3.2.0'
-//    compile 'com.squareup.okhttp3:logging-interceptor:3.2.0'
-//    compile 'com.squareup.retrofit2:retrofit:2.1.0'
-//    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
-
 }

--- a/app/src/main/java/com/example/replacefragments/MainActivity.java
+++ b/app/src/main/java/com/example/replacefragments/MainActivity.java
@@ -26,18 +26,15 @@ public class MainActivity extends AppCompatActivity implements
     // Used to store the last screen title. For use in {@link #restoreActionBar()}.
     private CharSequence mTitle;
 
-    private AppCompatActivity mActivity;
-
     // only load fragment on fresh start
     // don't reload when re-displaying or orientation change
     private boolean reloadFragment = true;
+    private FragmentChange mFragmentChange;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        mActivity = this;
-
+        mFragmentChange = new FragmentChange(getSupportFragmentManager());
         // Data gets populated from SQLite here, usually
 
     } // end onCreate
@@ -104,9 +101,7 @@ public class MainActivity extends AppCompatActivity implements
         FragmentChangeEvent fragmentChangeEvent = new FragmentChangeEvent(null);
         fragmentChangeEvent.setPosition(position);
         fragmentChangeEvent.setVersion(version);
-        FragmentChange fragmentChange = FragmentChange.getInstance( getSupportFragmentManager());
-        fragmentChange.onFragmentChange(fragmentChangeEvent);
-
+        mFragmentChange.onFragmentChange(fragmentChangeEvent);
     }
 
     public void restoreActionBar() {
@@ -142,8 +137,7 @@ public class MainActivity extends AppCompatActivity implements
 
         FragmentChangeEvent fragmentChangeEvent = new FragmentChangeEvent(null);
         fragmentChangeEvent.setPosition(FRAGMENT_POP);
-        FragmentChange fragmentChange = FragmentChange.getInstance( getSupportFragmentManager());
-        boolean callSuper = fragmentChange.onFragmentPop(fragmentChangeEvent);
+        boolean callSuper = mFragmentChange.onFragmentPop(fragmentChangeEvent);
 
         if (callSuper) {
             super.onBackPressed();
@@ -152,48 +146,12 @@ public class MainActivity extends AppCompatActivity implements
     }
 
     @Override
-    protected void onPause() {
-        super.onPause();
-    }
-
-        @Override
     public void onSaveInstanceState(Bundle outState) {
-        outState.putString("WORKAROUND_FOR_BUG_19917_KEY", "WORKAROUND_FOR_BUG_19917_VALUE");
+        outState.putString("WORKAROUND_FOR_BUG_19917_KEY", "");
         super.onSaveInstanceState(outState);
     }
 
-    @Override
-    protected void onStop() {
-        super.onStop();
+    public FragmentChange getFragmentChange() {
+        return mFragmentChange;
     }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-    }
-
-    // Requires this line in the manifest file:
-    //     android:configChanges="orientation|screenSize"
-    // We override this to prevent the Activity from being restarted
-    // because restarting causes the fragment to be replaced causing this error:
-    //     IllegalStateException: Can not perform this action after onSaveInstanceState
-    // It is not necessary replace the fragment because the state is remembered by the OS.
-    // Simply overriding this method prevents the restart.
-    // See doc/IllegalStateException.txt for details on the error
-//    @Override
-//    public void onConfigurationChanged(Configuration newConfig) {
-//        super.onConfigurationChanged(newConfig);
-//
-//        isOrientationChange = true;
-//
-//        //setContentView(replacefragments.R.layout.activity_main);
-//
-//        // Checks the orientation of the screen
-//        if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-//            Toast.makeText(this, "landscape", Toast.LENGTH_SHORT).show();
-//        } else if (newConfig.orientation == Configuration.ORIENTATION_PORTRAIT){
-//            Toast.makeText(this, "portrait", Toast.LENGTH_SHORT).show();
-//        }
-//    }
-
 }

--- a/app/src/main/java/com/example/replacefragments/adapters/EmployeesRecyclerAdapter.java
+++ b/app/src/main/java/com/example/replacefragments/adapters/EmployeesRecyclerAdapter.java
@@ -29,7 +29,7 @@ public class EmployeesRecyclerAdapter extends RecyclerView.Adapter<EmployeesRecy
 
     private final String TAG = "EmployeesRecyclerAdapte";
 
-    private ArrayList<RowItem> mRowItems;
+    private ArrayList<RowItem> mRowItems = new ArrayList<>();
 
     private AdapterView.OnItemClickListener mOnItemClickListener;
 
@@ -37,19 +37,12 @@ public class EmployeesRecyclerAdapter extends RecyclerView.Adapter<EmployeesRecy
 
     // Can contain all employees, employees at a location, or employees at a division
     private ArrayList<EmployeeGeneratedData> employeeArrayList;
+    private FragmentChange mFragmentChange;
 
-    public EmployeesRecyclerAdapter() {
-
-        Log.d(TAG, "constructor: " + this);
-        mRowItems = new ArrayList<RowItem>();
-        mContext = null;
-    }
-
-    public EmployeesRecyclerAdapter(Context context) {
-
+    public EmployeesRecyclerAdapter(Context context, FragmentChange fragmentChange) {
         Log.d(TAG, "constructor: " + this + " context: " + context);
         mContext = context;
-        mRowItems = new ArrayList<RowItem>();
+        mFragmentChange = fragmentChange;
     }
 
     /*
@@ -120,8 +113,7 @@ public class EmployeesRecyclerAdapter extends RecyclerView.Adapter<EmployeesRecy
             fragmentChangeEvent.setPosition(FragmentChange.FRAGMENT_INDIVIDUAL);
             fragmentChangeEvent.setEmployeeDataParcelable(employeeDataParcelable);
 
-            FragmentChange fragmentChange = FragmentChange.getInstance(fragmentManager);
-            fragmentChange.onFragmentChange(fragmentChangeEvent);
+            mFragmentChange.onFragmentChange(fragmentChangeEvent);
 
             mOnItemClickListener.onItemClick(null, itemHolder.itemView,
                     itemHolder.getAdapterPosition(), itemHolder.getItemId());

--- a/app/src/main/java/com/example/replacefragments/fragments/EmployeesVerticalFragment.java
+++ b/app/src/main/java/com/example/replacefragments/fragments/EmployeesVerticalFragment.java
@@ -2,6 +2,7 @@ package com.example.replacefragments.fragments;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
@@ -11,6 +12,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.example.replacefragments.MainActivity;
 import com.example.replacefragments.R;
 import com.example.replacefragments.adapters.EmployeesRecyclerAdapter;
 import com.example.replacefragments.decoration.DividerDecoration;
@@ -30,6 +32,7 @@ public class EmployeesVerticalFragment extends RecyclerFragment {
     private static String divisonString = "NoDivision";
 
     protected EmployeesRecyclerAdapter mAdapter;
+    private FragmentChange mFragmentChange;
 
     public EmployeesVerticalFragment () {
     }
@@ -91,6 +94,15 @@ public class EmployeesVerticalFragment extends RecyclerFragment {
     }
 
     @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        // TODO: Define an interface to provide the FragmentChange.
+        // NB: this will crash with a ClassCastException with the fragment is used with the wrong
+        // context
+        mFragmentChange = ((MainActivity) getActivity()).getFragmentChange();
+    }
+
+    @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.fragment_recycler, container, false);
@@ -147,7 +159,6 @@ public class EmployeesVerticalFragment extends RecyclerFragment {
 
 //    @Override
     protected EmployeesRecyclerAdapter getAdapter() {
-
-        return new EmployeesRecyclerAdapter(getActivity());
+        return new EmployeesRecyclerAdapter(getActivity(), mFragmentChange);
     }
 }

--- a/app/src/main/java/com/example/replacefragments/fragments/FragmentChange.java
+++ b/app/src/main/java/com/example/replacefragments/fragments/FragmentChange.java
@@ -34,21 +34,9 @@ public class FragmentChange implements FragmentChangeListener {
     private FragmentManager mFragmentManager;
     private String version = "0";
 
-    public static FragmentChange getInstance(FragmentManager fragmentManager) {
-        if (instance == null) {
-            instance = new FragmentChange(fragmentManager);
-        }
-        return instance;
-    }
-
-    // constructor
-    private FragmentChange(FragmentManager fragmentManager) {
+    public FragmentChange(FragmentManager fragmentManager) {
         mFragmentManager = fragmentManager;
     }
-
-//    public void setOnEventListener(FragmentChangeListener listener) {
-//        mFragmentChangeListener = listener;
-//    }
 
     @Override
     public void onFragmentChange(FragmentChangeEvent fragmentChangeEvent) {


### PR DESCRIPTION
The FragmentManager is an Interface for interacting with Fragment objects *inside of an Activity*. It strikes me as a particular bad idea to have save it in a static field and reuse and old FragmentManager in a new activity. This will necessarily lead to Activity has been destroyed, when the new activity you interact with the manager from the old activity.

http://stackoverflow.com/a/40852599/94363